### PR TITLE
Show actual stack trace in exception dialog

### DIFF
--- a/src/main/kotlin/org/janelia/saalfeldlab/fx/ui/Exceptions.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/fx/ui/Exceptions.kt
@@ -45,14 +45,16 @@ class Exceptions {
     companion object {
 
         @JvmStatic
+        @JvmOverloads
         fun exceptionAlert(
                 title: String,
                 headerText: String,
-                e: Exception): Alert {
+                e: Exception,
+                contentText: String? = null): Alert {
             val alert = Alert(Alert.AlertType.ERROR)
             alert.title = title
             alert.headerText = headerText
-            alert.contentText = String.format("%s", e.message)
+            alert.contentText = contentText ?: e.message
 
             // Create expandable Exception.
             val stringWriter = StringWriter()
@@ -94,10 +96,12 @@ class Exceptions {
         }
 
         @JvmStatic
+        @JvmOverloads
         fun handler(
                 title: String,
-                headerText: String): Consumer<Exception> {
-            return Consumer { e -> exceptionAlert(title, headerText, e) }
+                headerText: String,
+                contentText: String? = null): Consumer<Exception> {
+            return Consumer { e -> exceptionAlert(title, headerText, e, contentText) }
         }
     }
 

--- a/src/main/kotlin/org/janelia/saalfeldlab/fx/ui/Exceptions.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/fx/ui/Exceptions.kt
@@ -56,10 +56,13 @@ class Exceptions {
             alert.headerText = headerText
             alert.contentText = contentText ?: e.message
 
+            // Get the root cause of the exception
+            val cause = getRootCause(e)
+
             // Create expandable Exception.
             val stringWriter = StringWriter()
             val printWriter = PrintWriter(stringWriter)
-            e.printStackTrace(printWriter)
+            cause.printStackTrace(printWriter)
             val exceptionText = stringWriter.toString()
 
             val label = Label("Stack trace:")
@@ -103,6 +106,14 @@ class Exceptions {
                 contentText: String? = null): Consumer<Exception> {
             return Consumer { e -> exceptionAlert(title, headerText, e, contentText) }
         }
+
+        private fun getRootCause(e: Throwable): Throwable {
+            var cause = e
+            while (cause.cause != null && cause.cause !== cause)
+                cause = cause.cause!!
+            return cause
+        }
+
     }
 
 }


### PR DESCRIPTION
In case an exception is re-thrown (possibly multiple times), the stack trace of the last re-throw was printed instead of the original exception's stack trace, so it was difficult to understand where the actual problem occurred.