### PR TITLE
fix: better device matching, esp on Windows

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/control/mcu/XTouchMiniMCUControlPanel.java
+++ b/src/main/java/org/janelia/saalfeldlab/control/mcu/XTouchMiniMCUControlPanel.java
@@ -157,7 +157,8 @@ public class XTouchMiniMCUControlPanel extends MCUControlPanel {
 
 		for (final Info info : MidiSystem.getMidiDeviceInfo()) {
 			final MidiDevice device = MidiSystem.getMidiDevice(info);
-			if (info.getDescription().contains(deviceDescription)) {
+			final String lowerDeviceDescription = deviceDescription.toLowerCase();
+			if (info.getDescription().toLowerCase().contains(lowerDeviceDescription) || info.getName().toLowerCase().contains(lowerDeviceDescription)) {
 				if (device.getMaxTransmitters() != 0) {
 					transDev = device;
 					trans = device.getTransmitter();


### PR DESCRIPTION
Windows and Linux Midi descriptions are not the same; check name as well.