### PR TITLE
feat!: make keyTracker a supplier

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,8 @@
 		<!-- JavaFx-->
 		<javafx.version>16</javafx.version>
 		<dokka.version>1.4.30</dokka.version>
+		<!-- Kotlin project, uuse dokka instead -->
+		<maven.javadoc.skip>true</maven.javadoc.skip>
 	</properties>
 
 	<developers>

--- a/src/main/kotlin/org/janelia/saalfeldlab/fx/actions/Action.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/fx/actions/Action.kt
@@ -98,9 +98,9 @@ open class Action<E : Event>(val eventType: EventType<E>) {
 	var keysExclusive = false
 
 	/**
-	 * Key tracker used to [verifyKeys]. If not provided, all calls to [verifyKeys] will return `false`, UNLESS [ignoreKeys] was called.
+	 * Key tracker provider used to [verifyKeys]. If not provided, all calls to [verifyKeys] will return `false`, UNLESS [ignoreKeys] was called.
 	 */
-	var keyTracker: KeyTracker? = null
+	var keyTracker: () -> KeyTracker? = { null }
 
 	/**
 	 * List of Keys required to be down for this action to be valid
@@ -174,11 +174,11 @@ open class Action<E : Event>(val eventType: EventType<E>) {
 		 *  - If we strictly expect no keys to be down
 		 *  - If ONLY the keys we expect are down
 		 *  - If AT LEAST the keys we expect are down  */
-		return keyTracker?.run {
+		return keyTracker()?.run {
 			when {
 				keysDown!!.isEmpty() && !keysExclusive -> true
 				keysDown!!.isEmpty() -> noKeysActive().also { if (!it) logger.trace("expected no keys, but some were down") }
-				keysExclusive -> areOnlyTheseKeysDown(*keysDown!!.toTypedArray()).also { if (!it) logger.trace("expected only these keys: ${keysDown}, but others were also down") }
+				keysExclusive -> areOnlyTheseKeysDown(*keysDown!!.toTypedArray()).also { if (!it) logger.trace("expected only these keys: ${keysDown}, but but active keys were: (${getActiveKeyCodes(true)}") }
 				else -> areKeysDown(*keysDown!!.toTypedArray()).also { if (!it) logger.trace("expected keys: $keysDown, but some were not down") }
 			}
 		} ?: let {

--- a/src/main/kotlin/org/janelia/saalfeldlab/fx/actions/ActionSet.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/fx/actions/ActionSet.kt
@@ -22,7 +22,8 @@ import java.util.function.Consumer
  * For example, you may want your application to change state based on a key press, and to revert on key relase:
  * ```kotlin
  * val node : Node = StackPane()
- * val changeStateActionSet = ActionSet("Change Application State", KeyTracker()) {
+ * val keyTracker : KeyTracker = KeyTracker()
+ * val changeStateActionSet = ActionSet("Change Application State", { keyTracker }) {
  *  KeyEvent.KEY_PRESSED(KeyCode.SPACE) {
  *      filter = true
  *      onAction { App.changeState() }
@@ -49,10 +50,10 @@ import java.util.function.Consumer
  *
  * @param apply configuration callback to configure this [ActionSet], and to create [Action]s
  */
-open class ActionSet(val name: String, var keyTracker: KeyTracker? = null, apply: (ActionSet.() -> Unit)? = null) {
+open class ActionSet(val name: String, var keyTracker: () -> KeyTracker? = { null }, apply: (ActionSet.() -> Unit)? = null) {
 
 	@JvmOverloads
-	constructor(name: String, keyTracker: KeyTracker? = null, apply: Consumer<ActionSet>?) : this(name, keyTracker, { apply?.accept(this) })
+	constructor(name: String, keyTracker: () -> KeyTracker? = { null }, apply: Consumer<ActionSet>?) : this(name, keyTracker, { apply?.accept(this) })
 
 	val actions = mutableListOf<Action<out Event>>()
 	private val actionHandlerMap = mutableMapOf<EventType<Event>, MutableList<EventHandler<Event>>>()

--- a/src/main/kotlin/org/janelia/saalfeldlab/fx/actions/DragActionSet.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/fx/actions/DragActionSet.kt
@@ -19,11 +19,11 @@ import java.util.function.Consumer
  * @constructor create the [DragActionSet], and initialize the contained [Action]s
  *
  * @param name of the [DragActionSet];
- * @param keyTracker to track the key state
+ * @param keyTracker to provide the key tracker to track the key state
  * @param filter to apply before triggering a drag event (Only [DRAG_DETECTED] and [MOUSE_DRAGGED] are drag events)
  * @param apply configuration callback for the created [DragActionSet]
  */
-open class DragActionSet @JvmOverloads constructor(name: String, keyTracker: KeyTracker? = null, filter: Boolean = true, apply: (DragActionSet.() -> Unit)? = null) : ActionSet(name, keyTracker) {
+open class DragActionSet @JvmOverloads constructor(name: String, keyTracker: () -> KeyTracker? = { null }, filter: Boolean = true, apply: (DragActionSet.() -> Unit)? = null) : ActionSet(name, keyTracker) {
 
 	/**
 	 * [DRAG_DETECTED] [Action]. Can be access for further configuration

--- a/src/main/kotlin/org/janelia/saalfeldlab/fx/actions/KeyAction.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/fx/actions/KeyAction.kt
@@ -49,6 +49,7 @@ class KeyAction(eventType: EventType<KeyEvent>) : Action<KeyEvent>(eventType) {
 	fun keysReleased(vararg keyCodes: KeyCode) {
 		ignoreKeys()
 		verify {
+			val keyTracker = keyTracker()
 			val otherKeys = keyTracker?.getActiveKeyCodes(true)
 			val otherKeysAreDown = otherKeys?.let { keyTracker?.areKeysDown(*otherKeys.toTypedArray()) } ?: false
 			val onlyOtherKeys = keyTracker?.activeKeyCount() == otherKeys?.size && (otherKeys?.size ?: -1) > 0
@@ -66,7 +67,7 @@ class KeyAction(eventType: EventType<KeyEvent>) : Action<KeyEvent>(eventType) {
 			val otherKeys = it - keyReleased
 			eventType == KeyEvent.KEY_RELEASED && /*ensure we are a KEY_RELEASED event */
 					(it.isEmpty() || keyReleased in it) && /* ensure the key that was released was a trigger key*/
-					keyTracker?.areKeysDown(*otherKeys.toTypedArray()) ?: false /* ensure all OTHER trigger keys are down. */
+					keyTracker()?.areKeysDown(*otherKeys.toTypedArray()) ?: false /* ensure all OTHER trigger keys are down. */
 		} ?: true
 		return keysValid.also {
 			if (!it) logger.trace("keys invalid")

--- a/src/main/kotlin/org/janelia/saalfeldlab/fx/event/KeyTracker.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/fx/event/KeyTracker.kt
@@ -42,7 +42,7 @@ class KeyTracker {
 	private val activeKeys = mutableSetOf<KeyCode>()
 
 	private val actions by lazy {
-		ActionSet("Key Tracker", this) {
+		ActionSet("Key Tracker", { this }) {
 			KEY_PRESSED {
 				ignoreKeys()
 				filter = true

--- a/src/main/kotlin/org/janelia/saalfeldlab/fx/midi/MidiActionSet.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/fx/midi/MidiActionSet.kt
@@ -10,7 +10,7 @@ import org.janelia.saalfeldlab.fx.actions.ActionSet
 import org.janelia.saalfeldlab.fx.event.KeyTracker
 import java.util.function.IntConsumer
 
-open class MidiActionSet(name: String, private val device: MCUControlPanel, private val target: EventTarget, keyTracker: KeyTracker? = null, callback: MidiActionSet.() -> Unit = {}) : ActionSet(name, keyTracker) {
+open class MidiActionSet(name: String, private val device: MCUControlPanel, private val target: EventTarget, keyTracker: () -> KeyTracker? = { null }, callback: MidiActionSet.() -> Unit = {}) : ActionSet(name, keyTracker) {
 	init {
 		callback()
 	}


### PR DESCRIPTION
keyTracker for Actions and ActionSets is now a () -> KeyTracker. This is to support situations where the key tracker may change after declaring the actionSet.