### PR TITLE
Feat/1.1.0

### DIFF
--- a/doc/xtouchmini-mcu-midi-map.txt
+++ b/doc/xtouchmini-mcu-midi-map.txt
@@ -1,0 +1,100 @@
+## input
+
+x90  x28  key 2   x00 off
+                  x01 blink
+                  x7f on
+x90  x29  key 3   x00 off
+                  x01 blink
+                  x7f on
+x90  x2a  key 4   x00 off
+                  x01 blink
+                  x7f on
+x90  x2b  key 5   x00 off
+                  x01 blink
+                  x7f on
+x90  x2c  key 6   x00 off
+                  x01 blink
+                  x7f on
+x90  x2d  key 7   x00 off
+                  x01 blink
+                  x7f on
+x90  x54  key 16  x00 off
+                  x01 blink
+                  x7f on
+x90  x55  key 17  x00 off
+                  x01 blink
+                  x7f on
+x90  x57  key 8   x00 off
+                  x01 blink
+                  x7f on
+x90  x58  key 9   x00 off
+                  x01 blink
+                  x7f on
+x90  x59  key 0   x00 off
+                  x01 blink
+                  x7f on
+x90  x5a  key 1   x00 off
+                  x01 blink
+                  x7f on
+x90  x5b  key 10  x00 off
+                  x01 blink
+                  x7f on
+x90  x5c  key 11  x00 off
+                  x01 blink
+                  x7f on
+x90  x5d  key 13  x00 off
+                  x01 blink
+                  x7f on
+x90  x5e  key 14  x00 off
+                  x01 blink
+                  x7f on
+x90  x5f  key 15  x00 off
+                  x01 blink
+                  x7f on
+
+xb0  x30--x37  vpot 0--7   x00 off
+                           x01--x0b 0100000000000--0000000000010 
+                           x10 off
+                           x11--x15 0111111000000--0000011000000
+                           x17 0000001000000
+                           x17--x1b 0000001100000--0000001111110
+                           x20 off
+                           x21--x2b 0100000000000--0111111111110
+                           x30 off
+                           x31--x36 0000001000000--0111111111110
+
+## output
+
+vpot 0--7  x90  x20--x27  x00 off  
+                          x7f on
+key 0      x90  x59       x00 off
+                          x7f on
+key 1      x90  x5a       x00 off
+                          x7f on
+key 2--7   x90  x28--x2d  x00 off
+                          x7f on
+key 8      x90  x57       x00 off
+                          x7f on
+key 9      x90  x58       x00 off
+                          x7f on
+key 10     x90  x5b       x00 off
+                          x7f on
+key 11     x90  x5c       x00 off
+                          x7f on
+key 10     x90  x5b       x00 off
+                          x7f on
+key 12     x90  x56       x00 off
+                          x7f on
+key 13-15  x90  x5d--x5f  x00 off
+                          x7f on
+key 16     x90  x54       x00 off
+                          x7f on
+key 17     x90  x55       x00 off
+                          x7f on
+
+vpot 0--7  xb0  x10--17   x01--x07 up
+                          x41--x47 down
+
+fader      xe8  x00       x40--x7f,x00--x3f (-64--63)
+                         
+                         

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
 	<groupId>org.janelia.saalfeldlab</groupId>
 	<artifactId>saalfx</artifactId>
-	<version>1.0.1-SNAPSHOT</version>
+	<version>1.1.0-SNAPSHOT</version>
 
 	<name>Saal FX</name>
 	<description>Saalfeld lab JavaFX tools and extensions</description>

--- a/src/main/kotlin/org/janelia/saalfeldlab/fx/actions/Action.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/fx/actions/Action.kt
@@ -74,7 +74,9 @@ import java.util.function.Consumer
 open class Action<E : Event>(val eventType: EventType<E>) {
 
 	val logger: Logger by lazy {
-		LoggerFactory.getLogger(name ?: this.toString())
+		val simpleName = this::class.simpleName?.let { ".$it" } ?: ""
+		val name = ".${name ?: "event-${eventType.name}"}"
+		LoggerFactory.getLogger("saalfx.action$simpleName$name")
 	}
 
 	/**
@@ -178,7 +180,7 @@ open class Action<E : Event>(val eventType: EventType<E>) {
 			when {
 				keysDown!!.isEmpty() && !keysExclusive -> true
 				keysDown!!.isEmpty() -> noKeysActive().also { if (!it) logger.trace("expected no keys, but some were down") }
-				keysExclusive -> areOnlyTheseKeysDown(*keysDown!!.toTypedArray()).also { if (!it) logger.trace("expected only these keys: ${keysDown}, but but active keys were: (${getActiveKeyCodes(true)}") }
+				keysExclusive -> areOnlyTheseKeysDown(*keysDown!!.toTypedArray()).also { if (!it) logger.trace("expected only these keys: ${keysDown}, but active keys were: (${getActiveKeyCodes(true)}") }
 				else -> areKeysDown(*keysDown!!.toTypedArray()).also { if (!it) logger.trace("expected keys: $keysDown, but some were not down") }
 			}
 		} ?: let {
@@ -303,12 +305,13 @@ open class Action<E : Event>(val eventType: EventType<E>) {
 				/* isValid(event) will only be true if event is E */
 				action(event)
 			} catch (e: Exception) {
+				logger.debug("Exception caught: ${e.message}")
 				exceptionHandler?.invoke(e) ?: throw e
 			}
 			if (consume) {
 				event?.consume()
 			}
-			logger.trace("$name completed successfully")
+			logger.debug("completed successfully")
 			true
 		} else {
 			if (!isConsumed) {

--- a/src/main/kotlin/org/janelia/saalfeldlab/fx/actions/MouseCombination.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/fx/actions/MouseCombination.kt
@@ -15,7 +15,7 @@ class MouseCombination private constructor(keyCombination: KeyCombination) {
 
 	constructor(keyCode: KeyCode, vararg modifier: KeyCombination.Modifier) : this(KeyCodeCombination(keyCode, *modifier))
 
-	constructor(vararg modifier: KeyCombination.Modifier) : this(OnlyModifierKeyCombination(*modifier))
+	constructor(vararg modifier: KeyCombination.Modifier) : this(NamedKeyCombination.OnlyModifierKeyCombination(*modifier))
 
 	private val _keyCombination: ObjectProperty<KeyCombination> = SimpleObjectProperty(keyCombination)
 
@@ -24,8 +24,8 @@ class MouseCombination private constructor(keyCombination: KeyCombination) {
 		set(keyCombination) = setKeyCombinationChecked(keyCombination)
 
 	private fun setKeyCombinationChecked(keyCombination: KeyCombination) {
-		require(keyCombination is KeyCodeCombination || keyCombination is OnlyModifierKeyCombination) {
-			"Currently only ${KeyCodeCombination::class} and ${OnlyModifierKeyCombination::class} are supported but got $keyCombination."
+		require(keyCombination is KeyCodeCombination || keyCombination is NamedKeyCombination.OnlyModifierKeyCombination) {
+			"Currently only ${KeyCodeCombination::class} and ${NamedKeyCombination.OnlyModifierKeyCombination::class} are supported but got $keyCombination."
 		}
 		_keyCombination.value = keyCombination
 	}
@@ -56,8 +56,6 @@ class MouseCombination private constructor(keyCombination: KeyCombination) {
 
 	val deepCopy: MouseCombination
 		get() = MouseCombination(keyCombination)
-
-	class OnlyModifierKeyCombination(vararg modifier: Modifier) : KeyCombination(*modifier)
 
 	companion object {
 		private val LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass())

--- a/src/main/kotlin/org/janelia/saalfeldlab/fx/actions/NamedKeyCombination.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/fx/actions/NamedKeyCombination.kt
@@ -1,25 +1,47 @@
 package org.janelia.saalfeldlab.fx.actions
 
+import com.sun.javafx.tk.Toolkit
 import javafx.beans.property.SimpleObjectProperty
-import javafx.scene.input.KeyCode
-import javafx.scene.input.KeyCodeCombination
-import javafx.scene.input.KeyCombination
-import javafx.scene.input.KeyEvent
+import javafx.scene.input.*
 import org.apache.commons.lang.builder.ToStringBuilder
 import org.apache.commons.lang.builder.ToStringStyle
 import org.janelia.saalfeldlab.fx.extensions.nonnull
 import kotlin.collections.set
 
-class NamedKeyCombination(val name: String, primaryCombination: KeyCodeCombination) {
+private val KeyCombination.modifierCodes: Set<KeyCode>
+	get() = setOfNotNull(
+		if (shift == KeyCombination.ModifierValue.DOWN) KeyCode.SHIFT else null,
+		if (control == KeyCombination.ModifierValue.DOWN) KeyCode.CONTROL else null,
+		if (alt == KeyCombination.ModifierValue.DOWN) KeyCode.ALT else null,
+		if (meta == KeyCombination.ModifierValue.DOWN) KeyCode.META else null,
+		if (shortcut == KeyCombination.ModifierValue.DOWN) Toolkit.getToolkit().platformShortcutKey else null
+	)
 
-	constructor(name: String, keyCode: KeyCode, vararg modifiers: KeyCombination.Modifier) : this(name, KeyCodeCombination(keyCode, *modifiers))
+private val KeyEvent.modifierCodes: Set<KeyCode>
+	get() = setOfNotNull(
+		if (isShiftDown) KeyCode.SHIFT else null,
+		if (isControlDown) KeyCode.CONTROL else null,
+		if (isAltDown) KeyCode.ALT else null,
+		if (isMetaDown) KeyCode.META else null,
+		if (isShortcutDown) Toolkit.getToolkit().platformShortcutKey else null
+	)
+
+class NamedKeyCombination(val name: String, primaryCombination: KeyCombination) {
 
 	private val primaryCombinationProperty = SimpleObjectProperty(primaryCombination)
-	var primaryCombination: KeyCodeCombination by primaryCombinationProperty.nonnull()
+	var primaryCombination: KeyCombination by primaryCombinationProperty.nonnull()
 
 	fun primaryCombinationProperty() = primaryCombinationProperty
 
 	fun matches(event: KeyEvent) = primaryCombination.match(event)
+
+	val keyCodes: Set<KeyCode>
+		get() {
+			val codes = mutableSetOf<KeyCode>()
+			(primaryCombination as? KeyCodeCombination)?.code?.also { codes += it }
+			codes += primaryCombination.modifierCodes
+			return codes.toSet()
+		}
 
 	val deepCopy: NamedKeyCombination
 		get() = NamedKeyCombination(name, primaryCombination)
@@ -53,7 +75,16 @@ class NamedKeyCombination(val name: String, primaryCombination: KeyCodeCombinati
 			this[keyCombination.name] = keyCombination
 		}
 
-		fun matches(name: String, event: KeyEvent) = get(name)!!.matches(event)
+		fun matches(name: String, event: KeyEvent, keysExclusive : Boolean = true) : Boolean {
+			val namedCombo = get(name)!!
+			return if (keysExclusive) {
+				namedCombo.matches(event)
+			} else {
+				val combo = namedCombo.primaryCombination
+				val codesMatchIfCodeCombo = (combo as? KeyCodeCombination)?.code?.let { it == event.code } ?: true
+				codesMatchIfCodeCombo && event.modifierCodes.containsAll(combo.modifierCodes)
+			}
+		}
 
 		operator fun plusAssign(keyCombination: NamedKeyCombination) = addCombination(keyCombination)
 
@@ -65,6 +96,12 @@ class NamedKeyCombination(val name: String, primaryCombination: KeyCodeCombinati
 
 		val deepCopy: CombinationMap
 			get() = values.map { it.deepCopy }.toTypedArray().let { CombinationMap(*it) }
+	}
+
+	class OnlyModifierKeyCombination(vararg modifier: Modifier) : KeyCombination(*modifier) {
+		override fun match(event: KeyEvent?): Boolean {
+			return super.match(event)
+		}
 	}
 
 }

--- a/src/main/kotlin/org/janelia/saalfeldlab/fx/event/KeyTracker.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/fx/event/KeyTracker.kt
@@ -44,6 +44,7 @@ class KeyTracker {
 	private val actions by lazy {
 		ActionSet("Key Tracker", { this }) {
 			KEY_PRESSED {
+				name = "key-pressed"
 				ignoreKeys()
 				filter = true
 				consume = false
@@ -51,6 +52,7 @@ class KeyTracker {
 				onAction { addKey(it!!.code) }
 			}
 			KEY_RELEASED {
+				name = "key-released"
 				ignoreKeys()
 				filter = true
 				consume = false

--- a/src/main/kotlin/org/janelia/saalfeldlab/fx/midi/MidiActionSet.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/fx/midi/MidiActionSet.kt
@@ -46,33 +46,35 @@ open class MidiActionSet(name: String, private val device: MCUControlPanel, priv
 
 	@JvmSynthetic
 	fun potentiometerAction(eventType: EventType<MidiPotentiometerEvent>, handle: Int, withAction: PotentiometerAction.() -> Unit = {}): PotentiometerAction {
-		return PotentiometerAction(eventType, device, handle, withAction).also { addAction(it) }
+		return PotentiometerAction(eventType, device, handle, name, withAction).also { addAction(it) }
 	}
 
 	@JvmSynthetic
 	fun toggleAction(eventType: EventType<MidiToggleEvent>, handle: Int, withAction: ToggleAction.() -> Unit = {}): ToggleAction {
-		return ToggleAction(eventType, device, handle, withAction).also { addAction(it) }
+		return ToggleAction(eventType, device, handle, name, withAction).also { addAction(it) }
 	}
 
 	@JvmSynthetic
 	fun buttonAction(eventType: EventType<MidiButtonEvent>, handle: Int, withAction: ButtonAction.() -> Unit = {}): ButtonAction {
-		return ButtonAction(eventType, device, handle, withAction).also { addAction(it) }
+		return ButtonAction(eventType, device, handle, name, withAction).also { addAction(it) }
 	}
 
 	@JvmSynthetic
 	fun faderAction(eventType: EventType<MidiFaderEvent>, handle: Int, withAction: FaderAction.() -> Unit = {}): FaderAction {
-		return FaderAction(eventType, device, handle, withAction).also { addAction(it) }
+		return FaderAction(eventType, device, handle, name, withAction).also { addAction(it) }
 	}
 
 }
 
-abstract class MidiAction<E : FxMidiEvent>(eventType: EventType<E>, val device: MCUControlPanel, val handle: Int, withAction: MidiAction<E>.() -> Unit = {}) : Action<E>(eventType) {
+abstract class MidiAction<E : FxMidiEvent>(eventType: EventType<E>, val device: MCUControlPanel, val handle: Int, name : String? = null, withAction: MidiAction<E>.() -> Unit = {}) : Action<E>(eventType) {
 	abstract val control: MCUControl
 	protected abstract var eventFiringListener: IntConsumer?
 	var supressEvents = false
 
 	init {
 		ignoreKeys()
+		/* set the default name*/
+		name?.let { this.name = it }
 		apply(withAction)
 	}
 
@@ -98,7 +100,7 @@ abstract class MidiAction<E : FxMidiEvent>(eventType: EventType<E>, val device: 
 	}
 }
 
-class PotentiometerAction(eventType: EventType<MidiPotentiometerEvent>, device: MCUControlPanel, handle: Int, withAction: PotentiometerAction.() -> Unit = {}) : MidiAction<MidiPotentiometerEvent>(eventType, device, handle) {
+class PotentiometerAction(eventType: EventType<MidiPotentiometerEvent>, device: MCUControlPanel, handle: Int, name : String? = null,  withAction: PotentiometerAction.() -> Unit = {}) : MidiAction<MidiPotentiometerEvent>(eventType, device, handle, name) {
 
 	override val control: MCUVPotControl = device.getVPotControl(handle)
 	override var eventFiringListener: IntConsumer? = null
@@ -155,7 +157,7 @@ class PotentiometerAction(eventType: EventType<MidiPotentiometerEvent>, device: 
 	}
 }
 
-class ButtonAction(eventType: EventType<MidiButtonEvent>, device: MCUControlPanel, handle: Int, withAction: ButtonAction.() -> Unit = {}) : MidiAction<MidiButtonEvent>(eventType, device, handle) {
+class ButtonAction(eventType: EventType<MidiButtonEvent>, device: MCUControlPanel, handle: Int, name : String? = null,withAction: ButtonAction.() -> Unit = {}) : MidiAction<MidiButtonEvent>(eventType, device, handle, name) {
 
 	override val control: MCUButtonControl = device.getButtonControl(handle)
 	override var eventFiringListener: IntConsumer? = null
@@ -186,7 +188,7 @@ class ButtonAction(eventType: EventType<MidiButtonEvent>, device: MCUControlPane
 	}
 }
 
-class ToggleAction(eventType: EventType<MidiToggleEvent>, device: MCUControlPanel, handle: Int, withAction: ToggleAction.() -> Unit = {}) : MidiAction<MidiToggleEvent>(eventType, device, handle) {
+class ToggleAction(eventType: EventType<MidiToggleEvent>, device: MCUControlPanel, handle: Int, name : String? = null,  withAction: ToggleAction.() -> Unit = {}) : MidiAction<MidiToggleEvent>(eventType, device, handle, name) {
 
 	override val control: MCUButtonControl = device.getButtonControl(handle)
 	override var eventFiringListener: IntConsumer? = null
@@ -218,7 +220,7 @@ class ToggleAction(eventType: EventType<MidiToggleEvent>, device: MCUControlPane
 
 }
 
-class FaderAction(eventType: EventType<MidiFaderEvent>, device: MCUControlPanel, handle: Int, withAction: FaderAction.() -> Unit = {}) : MidiAction<MidiFaderEvent>(eventType, device, handle) {
+class FaderAction(eventType: EventType<MidiFaderEvent>, device: MCUControlPanel, handle: Int, name : String? = null, withAction: FaderAction.() -> Unit = {}) : MidiAction<MidiFaderEvent>(eventType, device, handle, name) {
 
 	override val control: MCUFaderControl = device.getFaderControl(handle)
 	override var eventFiringListener: IntConsumer? = null

--- a/src/main/kotlin/org/janelia/saalfeldlab/fx/ui/ResizeOnLeftSide.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/fx/ui/ResizeOnLeftSide.kt
@@ -64,7 +64,7 @@ class ResizeOnLeftSide @JvmOverloads constructor(
 	private val mouseDragged = DragActionSet("resize") {
 		verify { isCurrentlyWithinMarginOfBorder }
 
-		updateXY = false
+		relative = false
 
 		dragDetectedAction.filter = true
 		dragAction.filter = true

--- a/src/main/kotlin/org/janelia/saalfeldlab/fx/ui/resize/ResizeHorizontally.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/fx/ui/resize/ResizeHorizontally.kt
@@ -73,7 +73,7 @@ class ResizeHorizontally @JvmOverloads constructor(
 	}
 
 	private val mouseDragged = DragActionSet("resize horizontally") {
-		updateXY = false
+		relative = false
 		verify { canResize }
 		onDrag {
 			val dx = it.x - currentPosition


### PR DESCRIPTION
- Improvements to DragActionSet
  - choice of relative or absolute drag updates
  - optional initial drag start based on drag detection, OR on mouse down
- improved logger naming conventions for
- support for `onRelease` events for named keybindings
- support for modifier-online named keybindings