### PR TITLE
fix: MatchSelection Node initial cell height

### DIFF
--- a/src/main/kotlin/org/janelia/saalfeldlab/fx/extensions/ListViewExtensions.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/fx/extensions/ListViewExtensions.kt
@@ -11,7 +11,7 @@ fun ListView<*>.bindHeightToItemSize() {
 	val defaultMaxRows = 18
 	val cellHeightFallBack = 24.0
 	val prefHeightBinding: ObjectBinding<Double> = items.createObservableBinding {
-		val cellHeight = (lookup(".list-cell") as? ListCell<*>)?.height ?: cellHeightFallBack
+		val cellHeight = (lookup(".list-cell") as? ListCell<*>)?.height?.let { h -> if (h == 0.0) cellHeightFallBack else h } ?: cellHeightFallBack
 		val borderPadding = padding.top + padding.bottom
 		borderPadding + cellHeight * it.size.coerceAtMost(defaultMaxRows)
 	}

--- a/src/main/kotlin/org/janelia/saalfeldlab/fx/ui/MatchSelection.kt
+++ b/src/main/kotlin/org/janelia/saalfeldlab/fx/ui/MatchSelection.kt
@@ -99,22 +99,22 @@ class MatchSelection(
 			fuzzySearchField.requestFocus()
 			fuzzySearchField.selectEnd()
 		}
-		val currentOrder = FXCollections.observableArrayList<String>()
-		fuzzySearchField.textProperty().addListener { _, _, fuzzyFilter ->
-			val matches = when (emptyBehavior) {
-				EmptyBehavior.MATCH_ALL -> if (fuzzyFilter == null || fuzzyFilter.isEmpty()) candidates else matcher.apply(fuzzyFilter, candidates)
-				EmptyBehavior.MATCH_NONE -> matcher.apply(fuzzyFilter ?: "", candidates)
-			}
-			currentOrder.setAll(matches)
-		}
 
-		val labelList = ListView(currentOrder)
+		val labelList = ListView<String>()
 		labelList.selectionModel.selectionMode = SelectionMode.SINGLE
 		registerStyleSheet(labelList)
 
 		labelList.maxWidthProperty().bind(maxWidthProperty())
 		labelList.prefWidthProperty().bind(maxWidthProperty())
 		labelList.bindHeightToItemSize()
+
+		fuzzySearchField.textProperty().addListener { _, _, fuzzyFilter ->
+			val matches = when (emptyBehavior) {
+				EmptyBehavior.MATCH_ALL -> if (fuzzyFilter == null || fuzzyFilter.isEmpty()) candidates else matcher.apply(fuzzyFilter, candidates)
+				EmptyBehavior.MATCH_NONE -> matcher.apply(fuzzyFilter ?: "", candidates)
+			}
+			labelList.items.setAll(matches)
+		}
 
 
 		/* NOTE: I would have prefered that `labelList.scrollTo(idx)` would have worked here,


### PR DESCRIPTION
cell height was 0.0 at the start, so list would not show until typed, even when empty match behavior should show all matches